### PR TITLE
Created working snap for nap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,22 +5,17 @@ description: |
   Nap is a code snippet manager for your terminal. Create and access new snippets quickly with 
   the command-line interface or browse, manage, and organize them with the text-user interface. 
   Keep your code snippets safe, sound, and well-rested in your terminal.
-    
-license: MIT
-
+  
+  To learn more, visit: https://github.com/maaslalani/nap 
+  
 base: core20
 grade: stable 
 confinement: strict
 compression: lzo
 
-assumes:
-  - command-chain
-  
 apps:
   nap:
     command: bin/nap
-    command-chain: 
-      - bin/homeishome-launch     
     plugs:
       - home
       
@@ -34,9 +29,4 @@ parts:
       
     override-pull: |
       snapcraftctl pull
-      snapcraftctl set-version "$(git describe --tags | sed 's/^v//' | cut -d "-" -f1)"    
-  
-  homeishome-launch:
-    plugin: nil
-    stage-snaps:
-      - homeishome-launch     
+      snapcraftctl set-version "$(git describe --tags | sed 's/^v//' | cut -d "-" -f1)"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,42 @@
+name: nap
+adopt-info: nap
+summary: Nap is a code snippet manager for your terminal.
+description: |
+  Nap is a code snippet manager for your terminal. Create and access new snippets quickly with 
+  the command-line interface or browse, manage, and organize them with the text-user interface. 
+  Keep your code snippets safe, sound, and well-rested in your terminal.
+    
+license: MIT
+
+base: core22
+grade: stable 
+confinement: strict
+compression: lzo
+
+assumes:
+  - command-chain
+  
+apps:
+  nap:
+    command: bin/nap
+    command-chain: 
+      - bin/homeishome-launch     
+    plugs:
+      - home
+      
+parts:
+  nap:
+    source: https://github.com/maaslalani/nap
+    source-type: git
+    plugin: go
+    build-snaps:
+      - go
+      
+    override-pull: |
+      snapcraftctl pull
+      snapcraftctl set-version "$(git describe --tags | sed 's/^v//' | cut -d "-" -f1)"    
+  
+  homeishome-launch:
+    plugin: nil
+    stage-snaps:
+      - homeishome-launch     

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,7 +8,7 @@ description: |
     
 license: MIT
 
-base: core22
+base: core20
 grade: stable 
 confinement: strict
 compression: lzo


### PR DESCRIPTION
I'm working with snapcraft.io to get it published but someone registered the name `nap`. I've requested the name for publication. If you want, I can forego that and let you take the reigns. Otherwise, I can press forward with publishing and maintaining the snap.