### PR TITLE
Nap snap is now officially published

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,12 @@ Install with Go:
 ```sh
 go install github.com/maaslalani/nap@main
 ```
+[![nap-snippets](https://snapcraft.io/nap-snippets/badge.svg)](https://snapcraft.io/nap-snippets)
 
+Install the snap:
+```
+sudo snap install nap-snippets
+```
 Or download a binary from the [releases](https://github.com/maaslalani/nap/releases).
 
 

--- a/README.md
+++ b/README.md
@@ -128,12 +128,7 @@ Install with Go:
 ```sh
 go install github.com/maaslalani/nap@main
 ```
-[![nap-snippets](https://snapcraft.io/nap-snippets/badge.svg)](https://snapcraft.io/nap-snippets)
 
-Install the snap:
-```
-sudo snap install nap-snippets
-```
 Or download a binary from the [releases](https://github.com/maaslalani/nap/releases).
 
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ brew install nap
 # Arch
 yay -S nap
 
+# Snap
+sudo snap install nap-snippets
+
 # Nix
 nix-env -iA nixpkgs.nap
 ```

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,22 +5,17 @@ description: |
   Nap is a code snippet manager for your terminal. Create and access new snippets quickly with 
   the command-line interface or browse, manage, and organize them with the text-user interface. 
   Keep your code snippets safe, sound, and well-rested in your terminal.
-    
-license: MIT
-
+  
+  To learn more, visit: https://github.com/maaslalani/nap 
+  
 base: core20
 grade: stable 
 confinement: strict
 compression: lzo
 
-assumes:
-  - command-chain
-  
 apps:
   nap:
     command: bin/nap
-    command-chain: 
-      - bin/homeishome-launch     
     plugs:
       - home
       
@@ -34,9 +29,4 @@ parts:
       
     override-pull: |
       snapcraftctl pull
-      snapcraftctl set-version "$(git describe --tags | sed 's/^v//' | cut -d "-" -f1)"    
-  
-  homeishome-launch:
-    plugin: nil
-    stage-snaps:
-      - homeishome-launch     
+      snapcraftctl set-version "$(git describe --tags | sed 's/^v//' | cut -d "-" -f1)"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,12 +1,12 @@
-name: nap
-adopt-info: nap
+name: nap-snippets
+adopt-info: nap-snippets
 summary: Nap is a code snippet manager for your terminal.
 description: |
   Nap is a code snippet manager for your terminal. Create and access new snippets quickly with 
   the command-line interface or browse, manage, and organize them with the text-user interface. 
   Keep your code snippets safe, sound, and well-rested in your terminal.
   
-  To learn more, visit: https://github.com/maaslalani/nap 
+  To learn more, visit: https://github.com/maaslalani/nap
   
 base: core20
 grade: stable 
@@ -14,13 +14,13 @@ confinement: strict
 compression: lzo
 
 apps:
-  nap:
+  nap-snippets:
     command: bin/nap
     plugs:
       - home
       
 parts:
-  nap:
+  nap-snippets:
     source: https://github.com/maaslalani/nap
     source-type: git
     plugin: go

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,42 @@
+name: nap
+adopt-info: nap
+summary: Nap is a code snippet manager for your terminal.
+description: |
+  Nap is a code snippet manager for your terminal. Create and access new snippets quickly with 
+  the command-line interface or browse, manage, and organize them with the text-user interface. 
+  Keep your code snippets safe, sound, and well-rested in your terminal.
+    
+license: MIT
+
+base: core22
+grade: stable 
+confinement: strict
+compression: lzo
+
+assumes:
+  - command-chain
+  
+apps:
+  nap:
+    command: bin/nap
+    command-chain: 
+      - bin/homeishome-launch     
+    plugs:
+      - home
+      
+parts:
+  nap:
+    source: https://github.com/maaslalani/nap
+    source-type: git
+    plugin: go
+    build-snaps:
+      - go
+      
+    override-pull: |
+      snapcraftctl pull
+      snapcraftctl set-version "$(git describe --tags | sed 's/^v//' | cut -d "-" -f1)"    
+  
+  homeishome-launch:
+    plugin: nil
+    stage-snaps:
+      - homeishome-launch     

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,6 +12,7 @@ base: core20
 grade: stable 
 confinement: strict
 compression: lzo
+license: MIT
 
 apps:
   nap-snippets:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,7 +8,7 @@ description: |
     
 license: MIT
 
-base: core22
+base: core20
 grade: stable 
 confinement: strict
 compression: lzo


### PR DESCRIPTION
The snap is called `nap-snippets` but the Snapcraft folks applied an automatic alias for users. They can use the same commands in the README, etc. 

Made a couple of additions to the README to address snap installation and gave it a snap badge.