### PR TITLE
Fix issue where EDITOR set with arguments doesn't work

### DIFF
--- a/model.go
+++ b/model.go
@@ -380,11 +380,11 @@ func (m *Model) previousPane() {
 
 // editSnippet opens the editor with the selected snippet file path.
 func (m *Model) editSnippet() tea.Cmd {
-	editor := os.Getenv("EDITOR")
-	if editor == "" {
-		editor = "vim"
+	editor := strings.Split(os.Getenv("EDITOR"), " ")
+	if editor[0] == "" {
+		editor[0] = "vim"
 	}
-	cmd := exec.Command(editor, m.selectedSnippetFilePath())
+	cmd := exec.Command(editor[0], append(editor[1:], m.selectedSnippetFilePath())...)
 	return tea.ExecProcess(cmd, func(err error) tea.Msg {
 		return updateContentMsg(m.selectedSnippet())
 	})


### PR DESCRIPTION
Hey Maas :) Love this project!

I use `EDITOR='code -w'` but it doesn't work currently because `code -w` is set command name instead of `code` and `-w` passed as an argument. This fixes it as minimally as I could.