### PR TITLE
test: simplify editor and add testing

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,23 @@
+name: Test
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '>=1.19'
+
+      - name: Test
+        run: go test -v ./...
+
+      - name: Build
+        run: go build -v

--- a/editor.go
+++ b/editor.go
@@ -17,11 +17,8 @@ func editorCmd(path string) *exec.Cmd {
 
 func getEditor() (string, []string) {
 	editor := strings.Fields(os.Getenv("EDITOR"))
-	if len(editor) > 1 {
+	if len(editor) > 0 {
 		return editor[0], editor[1:]
 	}
-	if len(editor) == 1 {
-		return editor[0], []string{}
-	}
-	return defaultEditor, []string{}
+	return defaultEditor, nil
 }

--- a/editor_test.go
+++ b/editor_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestGetEditor(t *testing.T) {
+	tt := []struct {
+		Name      string
+		EditorEnv string
+		Cmd       string
+		Args      []string
+	}{
+		{
+			Name: "default",
+			Cmd:  "nano",
+		},
+		{
+			Name:      "vim",
+			EditorEnv: "vim",
+			Cmd:       "vim",
+		},
+		{
+			Name:      "vim with flag",
+			EditorEnv: "vim --foo",
+			Cmd:       "vim",
+			Args:      []string{"--foo"},
+		},
+		{
+			Name:      "code",
+			EditorEnv: "code -w",
+			Cmd:       "code",
+			Args:      []string{"-w"},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.Name, func(t *testing.T) {
+			var err error
+			switch tc.EditorEnv {
+			case "":
+				err = os.Unsetenv("EDITOR")
+			default:
+				err = os.Setenv("EDITOR", tc.EditorEnv)
+			}
+			if err != nil {
+				t.Logf("could not (un)set env: %v", err)
+				t.FailNow()
+			}
+
+			cmd, args := getEditor()
+
+			if cmd != tc.Cmd {
+				t.Logf("cmd is incorrect: want %q but got %q", tc.Cmd, cmd)
+				t.FailNow()
+			}
+
+			if argStr, tcArgStr := fmt.Sprint(args), fmt.Sprint(tc.Args); argStr != tcArgStr {
+				t.Logf("args are incorrect: want %q but got %q", tcArgStr, argStr)
+				t.FailNow()
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR does a minor simplification for `EDITOR` and adds a basic test with accompanying workflow.
