### PR TITLE
Add hidden alias for pane navigation (left / right arrow keys)

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -39,8 +39,8 @@ var DefaultKeyMap = KeyMap{
 	TagSnippet:    key.NewBinding(key.WithKeys("t"), key.WithHelp("t", "tag"), key.WithDisabled()),
 	Confirm:       key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "confirm")),
 	Cancel:        key.NewBinding(key.WithKeys("N", "esc"), key.WithHelp("N", "cancel")),
-	NextPane:      key.NewBinding(key.WithKeys("tab"), key.WithHelp("tab", "navigate")),
-	PreviousPane:  key.NewBinding(key.WithKeys("shift+tab"), key.WithHelp("shift+tab", "navigate")),
+	NextPane:      key.NewBinding(key.WithKeys("tab", "right"), key.WithHelp("tab", "navigate")),
+	PreviousPane:  key.NewBinding(key.WithKeys("shift+tab", "left"), key.WithHelp("shift+tab", "navigate")),
 	ChangeFolder:  key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "change folder"), key.WithDisabled()),
 }
 


### PR DESCRIPTION
Arrow keys are unused and provide an intuitive experience for pane navigation. I propose we add them as an alias.