### PR TITLE
feat: store state as strings

### DIFF
--- a/main.go
+++ b/main.go
@@ -346,22 +346,27 @@ func runInteractiveMode(config Config, snippets []Snippet) error {
 	folderList.Styles.NoItems = lipgloss.NewStyle().Margin(0, 2).Foreground(lipgloss.Color(config.GrayColor))
 	folderList.SetStatusBarItemName("folder", "folders")
 
-	folderNum := state.CurrentFolder
-	if folderNum >= len(folderList.Items()) {
-		folderNum = 0
+	for idx, folder := range foldersSlice {
+		if string(folder) == state.CurrentFolder {
+			folderList.Select(idx)
+			break
+		}
 	}
-	folderList.Select(folderNum)
 
 	content := viewport.New(80, 0)
 
 	lists := map[Folder]*list.Model{}
 
-	snippetNum := state.CurrentSnippet
 	currentFolder := folderList.SelectedItem().(Folder)
 	for folder, items := range folders {
 		snippetList := newList(items, 20, defaultStyles.Snippets.Focused)
-		if currentFolder == folder && snippetNum <= len(snippetList.Items()) {
-			snippetList.Select(snippetNum)
+		if folder == currentFolder {
+			for idx, item := range snippetList.Items() {
+				if s, ok := item.(Snippet); ok && s.File == state.CurrentSnippet {
+					snippetList.Select(idx)
+					break
+				}
+			}
 		}
 		lists[folder] = snippetList
 	}

--- a/model.go
+++ b/model.go
@@ -681,11 +681,9 @@ func (m *Model) View() string {
 }
 
 func (m *Model) saveState() {
-	selectedFolderIndex := m.Folders.Index()
-	selectedSnippetIndex := m.List().Index()
 	s := State{
-		CurrentFolder:  selectedFolderIndex,
-		CurrentSnippet: selectedSnippetIndex,
+		CurrentFolder:  string(m.selectedFolder()),
+		CurrentSnippet: m.selectedSnippet().File,
 	}
 	err := s.Save()
 	if err != nil {

--- a/state.go
+++ b/state.go
@@ -11,8 +11,8 @@ import (
 
 // State is application state between runs
 type State struct {
-	CurrentFolder  int
-	CurrentSnippet int
+	CurrentFolder  string
+	CurrentSnippet string
 }
 
 // Save saves the state of the application


### PR DESCRIPTION
resolves #39 

This will cause a one-time breakage* when state is loaded because the int won't decode into the new string values.

\* state loading fails gracefully, so "breakage" here just means your state will reset once

---

This should help make state more durable after #45 is merged