### PR TITLE
Don't Scan Hidden Directories For Snippets

### DIFF
--- a/main.go
+++ b/main.go
@@ -218,6 +218,9 @@ func scanSnippets(config Config, snippets []Snippet) []Snippet {
 		if !homeEntry.IsDir() {
 			continue
 		}
+		if strings.HasPrefix(homeEntry.Name(), ".") {
+			continue
+		}
 
 		folderPath := filepath.Join(config.Home, homeEntry.Name())
 		folderEntries, err := os.ReadDir(folderPath)


### PR DESCRIPTION
When scanning for new snippets, ignore hidden directories. We don't want to add a .git directory, for example.