### PR TITLE
feat: vim binds for right-left

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -43,8 +43,8 @@ var DefaultKeyMap = KeyMap{
 	TagSnippet:      key.NewBinding(key.WithKeys("t"), key.WithHelp("t", "tag"), key.WithDisabled()),
 	Confirm:         key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "confirm")),
 	Cancel:          key.NewBinding(key.WithKeys("N", "esc"), key.WithHelp("N", "cancel")),
-	NextPane:        key.NewBinding(key.WithKeys("tab", "right"), key.WithHelp("tab", "navigate")),
-	PreviousPane:    key.NewBinding(key.WithKeys("shift+tab", "left"), key.WithHelp("shift+tab", "navigate")),
+	NextPane:        key.NewBinding(key.WithKeys("tab", "right", "l"), key.WithHelp("tab", "navigate")),
+	PreviousPane:    key.NewBinding(key.WithKeys("shift+tab", "left", "h"), key.WithHelp("shift+tab", "navigate")),
 	ChangeFolder:    key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "change folder"), key.WithDisabled()),
 }
 


### PR DESCRIPTION
Resolves #52 

The bubble `List` type already has default keys that respect `j` and `k`, so this PR simply adds `h` and `l` for navigating panes.