### PR TITLE
feat: implement json schema for config

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,104 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "hexadecimal_color": {
+            "type": "string",
+            "pattern": "^\\S+$",
+            "examples": [
+                "#000000",
+                "#FF0000",
+                "#00FF00",
+                "#0000FF",
+                "#FFFF00",
+                "#FF00FF",
+                "#FFFFFF"
+            ]
+        },
+        "color_number": {
+            "type": "string",
+            "pattern": "^[0-7]$"
+        }
+    },
+    "title": "nap settings",
+    "description": "nap settings",
+    "type": "object",
+    "properties": {
+        "home": {
+            "title": "home",
+            "description": "A home directory\nhttps://github.com/maaslalani/nap?tab=readme-ov-file#customization",
+            "type": "string",
+            "minLength": 1,
+            "default": "~/.nap"
+        },
+        "default_language": {
+            "title": "default language",
+            "description": "A default language\nhttps://github.com/maaslalani/nap?tab=readme-ov-file#customization",
+            "type": "string",
+            "minLength": 1,
+            "default": "go"
+        },
+        "theme": {
+            "title": "theme",
+            "description": "A theme\nhttps://github.com/maaslalani/nap?tab=readme-ov-file#customization",
+            "type": "string",
+            "minLength": 1,
+            "default": "nord"
+        },
+        "background": {
+            "title": "background",
+            "description": "A background\nhttps://github.com/maaslalani/nap?tab=readme-ov-file#customization",
+            "$ref": "#/definitions/color_number"
+        },
+        "foreground": {
+            "title": "foreground",
+            "description": "A foreground\nhttps://github.com/maaslalani/nap?tab=readme-ov-file#customization",
+            "$ref": "#/definitions/color_number"
+        },
+        "primary_color": {
+            "title": "primary color",
+            "description": "A primary color\nhttps://github.com/maaslalani/nap?tab=readme-ov-file#customization",
+            "$ref": "#/definitions/hexadecimal_color"
+        },
+        "primary_color_subdued": {
+            "title": "primary color subdued",
+            "description": "A primary color subdued\nhttps://github.com/maaslalani/nap?tab=readme-ov-file#customization",
+            "$ref": "#/definitions/hexadecimal_color"
+        },
+        "green": {
+            "title": "green",
+            "description": "A green\nhttps://github.com/maaslalani/nap?tab=readme-ov-file#customization",
+            "$ref": "#/definitions/hexadecimal_color"
+        },
+        "bright_green": {
+            "title": "bright green",
+            "description": "A bright green\nhttps://github.com/maaslalani/nap?tab=readme-ov-file#customization",
+            "$ref": "#/definitions/hexadecimal_color"
+        },
+        "bright_red": {
+            "title": "bright red",
+            "description": "A bright red\nhttps://github.com/maaslalani/nap?tab=readme-ov-file#customization",
+            "$ref": "#/definitions/hexadecimal_color"
+        },
+        "red": {
+            "title": "red",
+            "description": "A red\nhttps://github.com/maaslalani/nap?tab=readme-ov-file#customization",
+            "$ref": "#/definitions/hexadecimal_color"
+        },
+        "black": {
+            "title": "black",
+            "description": "A black\nhttps://github.com/maaslalani/nap?tab=readme-ov-file#customization",
+            "$ref": "#/definitions/hexadecimal_color"
+        },
+        "gray": {
+            "title": "gray",
+            "description": "A gray\nhttps://github.com/maaslalani/nap?tab=readme-ov-file#customization",
+            "$ref": "#/definitions/hexadecimal_color"
+        },
+        "white": {
+            "title": "white",
+            "description": "A white\nhttps://github.com/maaslalani/nap?tab=readme-ov-file#customization",
+            "$ref": "#/definitions/hexadecimal_color"
+        }
+    },
+    "additionalProperties": false
+}


### PR DESCRIPTION
![image](https://github.com/maaslalani/nap/assets/42812113/04a6a55f-f831-4094-a09c-c89f7a659b6a)

Adds validation for config.

> If this PR is accepted this schema is referenced in [SchemaStore](https://github.com/SchemaStore/schemastore) to automatically enable validation for `**/nap/config.yaml`.

For a usage explanation, please consult [this](https://github.com/noahgorstein/jqp/pull/78#issuecomment-2129013241) my comment.